### PR TITLE
Update final export line for IE11

### DIFF
--- a/steal-svg.js
+++ b/steal-svg.js
@@ -5,5 +5,5 @@ exports.translate = function (load) {
   load.metadata.format = 'es6';
   load.source = load.source.replace(xmlTagRegex, '');
   load.source = load.source.replace(nsRegex, '');
-  load.source = `export default \`${load.source}\`;`;
+  load.source = "export default `" + load.source + "`;";
 };


### PR DESCRIPTION
IE11 had trouble with the string interpolation, and this change fixed it. In addition, I had to remove the xml/xmlns regular expressions to get the SVGs to load in IE11, as it kept throwing a regular expression syntax error. Removing the reg ex did not break this in any of the main modern browsers, but it might be just for my particular use case, so I did not add their removal to this PR.